### PR TITLE
Fix Secret Lab music crash

### DIFF
--- a/desktop_version/src/v6ap.cpp
+++ b/desktop_version/src/v6ap.cpp
@@ -176,7 +176,9 @@ void V6AP_PrintNext() {
 }
 
 void V6AP_AdjustMusic(int* x) {
-    *x = map_music.at(*x);
+    if (map_music.count(*x)) {
+        *x = map_music[*x];
+    }
 }
 
 int V6AP_PlayerIsEnteringArea(int x, int y) {


### PR DESCRIPTION
I'm not certain this is the best fix - the other option is wrapping the AdjustMusic call with a check for the Secret Lab track, but I have playtested this fix and it works.