### PR TITLE
Fixes text centering on trinket list in pause menu

### DIFF
--- a/desktop_version/src/Render.cpp
+++ b/desktop_version/src/Render.cpp
@@ -3224,7 +3224,7 @@ void maprender(void)
                     }
                 }
             }
-            font::print(PR_CEN | FLIP_PR_CJK_HIGH, 0, FLIP(76, 8), out, 96, 96, 96);
+            font::print(PR_CEN | FLIP_PR_CJK_LOW, -1, FLIP(76, 8), out, 96, 96, 96);
         }
 
         font::print(PR_CEN | FLIP_PR_CJK_HIGH, -1, FLIP(152, 8), loc::gettext("[Time Taken]"), 196, 196, 255 - help.glow);


### PR DESCRIPTION
This is a regression caused by the last rebase. The combination of flags currently given means centering *around* x coordinate 0.
Also I believe this is the correct CJK flag given the text location, but I haven't tested how it displays in languages with large fonts.